### PR TITLE
Fix malloc and strncpy macro behavior

### DIFF
--- a/src/common/utility.h
+++ b/src/common/utility.h
@@ -33,7 +33,7 @@ if (data != NULL) \
 
 
 #define MALLOC_AND_STRNCPY(out, in) \
-if ((out = malloc(strlen(in)+1)) == NULL) \
+if ((out = malloc(strlen(in)+1)) != NULL) \
     strncpy(out, in, strlen(in)+1);
 
 #define MALLOC_STRNCPY_OR_GOTO(out, in, goto_label) \
@@ -42,7 +42,7 @@ else \
     goto goto_label;
 
 #define MALLOC_AND_MEMCPY(out, in) \
-if ((out = malloc(sizeof(in))) == NULL) \
+if ((out = malloc(sizeof(in))) != NULL) \
     memcpy(out, in, sizeof(in));
 
 #define MALLOC_MEMCPY_OR_GOTO(out, in, goto_label) \


### PR DESCRIPTION
Currently the macro `MALLOC_AND_STRNCPY` will only execute `strncpy` if `malloc` fails. This is the opposite intended effect as we should be doing `strncpy` if `malloc` is successful. 

This PR fixes the `MALLOC_AND_STRNCPY` and `MALLOC_AND_MEMCPY` macros in `utility.h` to perform the `memcpy` or `strncpy` if `malloc` is successful. 