### PR TITLE
DxWiFi App

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,4 @@ CMakeCache.txt
 CMakeFiles
 doxygen_html
 index.html
+.vscode/

--- a/src/apps/CMakeLists.txt
+++ b/src/apps/CMakeLists.txt
@@ -5,6 +5,7 @@ set(APPS_SOURCES
     logind_app.c
     star_tracker_app.c
     systemd_app.c
+    dxwifi_app.c
     template_app.c
     )
 
@@ -13,6 +14,7 @@ set(APPS_HEADERS
     logind_app.h
     star_tracker_app.h
     systemd_app.h
+    dxwifi_app.h
     template_app.h
     )
 

--- a/src/apps/dxwifi_app.c
+++ b/src/apps/dxwifi_app.c
@@ -1,0 +1,39 @@
+/**
+ * OreSat Live DxWiFi daemon app
+ *
+ * @file        dxwifi_app.c
+ * @ingroup     apps
+ *
+ * This file is part of OreSat Linux Manager, a common CAN to Dbus interface
+ * for daemons running on OreSat Linux boards.
+ * Project home page is <https://github.com/oresat/oresat-linux-manager>.
+ */
+
+#include "globals.h"
+#include "log_message.h"
+#include "olm_app.h"
+#include "utility.h"
+#include "template_app.h"
+#include <errno.h>
+#include <stddef.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <systemd/sd-bus.h>
+
+/** App's name */
+#define APP_NAME            "DxWiFi"
+/** The systemd service name for the app's daemon */
+#define SERVICE_FILE        "oresat-dxwifi-txd.service"
+
+int
+dxwifi_app(olm_app_t *app) {
+    MALLOC_STRNCPY_OR_GOTO(app->name, APP_NAME, dxwifi_app_error);
+    MALLOC_STRNCPY_OR_GOTO(app->service_file, SERVICE_FILE, dxwifi_app_error);
+
+    return 1;
+
+dxwifi_app_error:
+
+    OLM_APP_FREE(app);
+    return -1;
+}

--- a/src/apps/dxwifi_app.h
+++ b/src/apps/dxwifi_app.h
@@ -9,11 +9,11 @@
  * Project home page is <https://github.com/oresat/oresat-linux-manager>.
  */
 
-#ifndef TEMPLATE_APP_H
-#define TEMPLATE_APP_H
+#ifndef DXWIFI_APP_H
+#define DXWIFI_APP_H
 
 #include "olm_app.h"
 
 int dxwifi_app(olm_app_t *app);
 
-#endif /* TEMPLATE_APP_H */
+#endif /* DXWIFI_APP_H */

--- a/src/apps/dxwifi_app.h
+++ b/src/apps/dxwifi_app.h
@@ -1,0 +1,19 @@
+/**
+ * OreSat Live DxWifi daemon app
+ *
+ * @file        dxwifi_app.h
+ * @ingroup     apps
+ *
+ * This file is part of OreSat Linux Manager, a common CAN to Dbus interface
+ * for daemons running on OreSat Linux boards.
+ * Project home page is <https://github.com/oresat/oresat-linux-manager>.
+ */
+
+#ifndef TEMPLATE_APP_H
+#define TEMPLATE_APP_H
+
+#include "olm_app.h"
+
+int dxwifi_app(olm_app_t *app);
+
+#endif /* TEMPLATE_APP_H */

--- a/src/boards/live/board_main.c
+++ b/src/boards/live/board_main.c
@@ -12,6 +12,7 @@
 #include "CANopen.h"
 #include "olm_app.h"
 #include "linux_updater_app.h"
+#include "dxwifi_app.h"
 #include "board_main.h"
 #include <stddef.h>
 #include <stdlib.h>
@@ -19,13 +20,15 @@
 
 // apps index in list
 #define LINUX_UPDATER_APP   0 // linux_updater_app is always 0
-#define TOTAL_APPS          LINUX_UPDATER_APP+1
+#define DXWIFI_APP          LINUX_UPDATER_APP+1
+#define TOTAL_APPS          DXWIFI_APP+1
 
-olm_app_t apps[TOTAL_APPS];
+olm_app_t apps[TOTAL_APPS] = {OLM_APP_INITIALIZER};
 
 olm_app_t *
 board_init(void) {
     linux_updater_app(&apps[LINUX_UPDATER_APP]);
+    dxwifi_app(&apps[DXWIFI_APP]);
     return apps;
 }
 


### PR DESCRIPTION
PR defines the DxWiFi daemon app and adds it to the OreSat Live board. 

The DxWiFi daemon app runs the `oresat-dxwifi-txd.service` daemon which is defined in the [oresat0](https://github.com/oresat/oresat-dxwifi-software/tree/oresat0/tx-rx) branch of the `oresat-dxwifi-software` repo. This daemon simply transmits a test sequence of bytes ad infinitum or until stopped. 